### PR TITLE
BUGFIX: Single file import

### DIFF
--- a/import.php
+++ b/import.php
@@ -33,7 +33,7 @@
                         }
                     }
                 } else {
-                    $import = static::sanitize($import);
+                    $import = static::sanitize($imports);
                     if (Utils::endswith($import, '.yaml')) {
                         $parsed = Yaml::parse($this->getContents($import));
                     } elseif (Utils::endswith($import, '.json')) {


### PR DESCRIPTION
Correct typo for page header when `imports` value is a string (single file) instead of an array (multiple files).