### PR TITLE
Update plugin homepage

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,13 +1,14 @@
 name: Import
 version: 1.1.0
 description: "Allows importing of user-defined YAML and JSON files to facilitate custom actions/settings"
+# Fork of https://github.com/Deester4x4jr/grav-plugin-import
 icon: paperclip
 author:
-  name: SquirrelFaktory
-  email: josh@desherlia.net
+  name: Perlkonig
+  email: ?
   # url: 
 keywords: plugin, import, yaml, json, files
-homepage: https://github.com/Deester4x4jr/grav-plugin-import
-bugs: https://github.com/Deester4x4jr/grav-plugin-import/issues
+homepage: https://github.com/Perlkonig/grav-plugin-import
+bugs: https://github.com/Perlkonig/grav-plugin-import/issues
 demo: https://perlkonig.com/demos/import
 license: MIT


### PR DESCRIPTION
Update `homepage` and `bugs` fields to point to https://github.com/Perlkonig/grav-plugin-import. (Other field updates may be required) 

After Grav update, noticed that the blueprint file still points to the older repo.

Email update? Any reference to original plugin in this file? Not sure what you'd like to do; just wanted to have the plugin updates pointing to your source.