### PR TITLE
BUGFIX: Stripping of 'data:' from imported file path

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,13 +1,14 @@
 name: Import
 version: 1.1.0
 description: "Allows importing of user-defined YAML and JSON files to facilitate custom actions/settings"
+# Fork of https://github.com/Deester4x4jr/grav-plugin-import
 icon: paperclip
 author:
-  name: SquirrelFaktory
-  email: josh@desherlia.net
+  name: Perlkonig
+  email: ?
   # url: 
 keywords: plugin, import, yaml, json, files
-homepage: https://github.com/Deester4x4jr/grav-plugin-import
-bugs: https://github.com/Deester4x4jr/grav-plugin-import/issues
+homepage: https://github.com/Perlkonig/grav-plugin-import
+bugs: https://github.com/Perlkonig/grav-plugin-import/issues
 demo: https://perlkonig.com/demos/import
 license: MIT

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,14 +1,13 @@
 name: Import
 version: 1.1.0
 description: "Allows importing of user-defined YAML and JSON files to facilitate custom actions/settings"
-# Fork of https://github.com/Deester4x4jr/grav-plugin-import
 icon: paperclip
 author:
-  name: Perlkonig
-  email: ?
+  name: SquirrelFaktory
+  email: josh@desherlia.net
   # url: 
 keywords: plugin, import, yaml, json, files
-homepage: https://github.com/Perlkonig/grav-plugin-import
-bugs: https://github.com/Perlkonig/grav-plugin-import/issues
+homepage: https://github.com/Deester4x4jr/grav-plugin-import
+bugs: https://github.com/Deester4x4jr/grav-plugin-import/issues
 demo: https://perlkonig.com/demos/import
 license: MIT

--- a/import.php
+++ b/import.php
@@ -48,7 +48,7 @@
         private function getContents($fn) {
             if (Utils::startswith($fn, 'data:')) {
                 $path = $this->grav['locator']->findResource('user://data', true);
-                $fn = ltrim($fn, 'data:');
+                $fn = ltrim(substr($fn, 5));
             } else {
                 $path = $this->grav['page']->path();
             }


### PR DESCRIPTION
Code was incorrectly replacing/trimming characters from the start of an import string if it started with 't' or 'd' or 'a'. For example, `data:testimonials.yaml` was converted to `user/data/estimonials.yaml`