### PR TITLE
PROPOSED: Modify resource resolution

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,13 +1,14 @@
 name: Import
 version: 1.1.0
 description: "Allows importing of user-defined YAML and JSON files to facilitate custom actions/settings"
+# Fork of https://github.com/Deester4x4jr/grav-plugin-import
 icon: paperclip
 author:
-  name: SquirrelFaktory
-  email: josh@desherlia.net
+  name: Perlkonig
+  email: ?
   # url: 
 keywords: plugin, import, yaml, json, files
-homepage: https://github.com/Deester4x4jr/grav-plugin-import
-bugs: https://github.com/Deester4x4jr/grav-plugin-import/issues
+homepage: https://github.com/Perlkonig/grav-plugin-import
+bugs: https://github.com/Perlkonig/grav-plugin-import/issues
 demo: https://perlkonig.com/demos/import
 license: MIT

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,14 +1,13 @@
 name: Import
 version: 1.1.0
 description: "Allows importing of user-defined YAML and JSON files to facilitate custom actions/settings"
-# Fork of https://github.com/Deester4x4jr/grav-plugin-import
 icon: paperclip
 author:
-  name: Perlkonig
-  email: ?
+  name: SquirrelFaktory
+  email: josh@desherlia.net
   # url: 
 keywords: plugin, import, yaml, json, files
-homepage: https://github.com/Perlkonig/grav-plugin-import
-bugs: https://github.com/Perlkonig/grav-plugin-import/issues
+homepage: https://github.com/Deester4x4jr/grav-plugin-import
+bugs: https://github.com/Deester4x4jr/grav-plugin-import/issues
 demo: https://perlkonig.com/demos/import
 license: MIT

--- a/import.php
+++ b/import.php
@@ -48,7 +48,7 @@
         private function getContents($fn) {
             if (Utils::startswith($fn, 'data:')) {
                 $path = $this->grav['locator']->findResource('user://data', true);
-                $fn = ltrim($fn, 'data:');
+                $fn = ltrim(substr($fn, 5));
             } else {
                 $path = $this->grav['page']->path();
             }

--- a/import.php
+++ b/import.php
@@ -23,12 +23,11 @@
                 if (is_array($imports)) {
                     foreach ($imports as $import) {
                         $import = static::sanitize($import);
-                        $key = str_replace('data:', '', $import);;
                         if (Utils::endswith($import, '.yaml')) {
-                            $key = str_replace('.yaml', '', $key);
+                            $key = basename($import, '.yaml');
                             $parsed[$key] = Yaml::parse($this->getContents($import));
                         } elseif (Utils::endswith($import, '.json')) {
-                            $key = str_replace('.json', '', $key);
+                            $key = basename($import, '.json');
                             $parsed[$key] = json_decode($this->getContents($import));
                         }
                     }
@@ -46,13 +45,11 @@
         }
 
         private function getContents($fn) {
-            if (Utils::startswith($fn, 'data:')) {
-                $path = $this->grav['locator']->findResource('user://data', true);
-                $fn = ltrim($fn, 'data:');
+            if (strpos($fn, '://') !== false ){
+                $path = $this->grav['locator']->findResource($fn, true);
             } else {
-                $path = $this->grav['page']->path();
+                $path = $this->grav['page']->path() . DS . $fn;
             }
-            $path = $path . DS . $fn;
             if (file_exists($path)) {
                 return file_get_contents($path);
             }
@@ -63,7 +60,6 @@
             $fn = trim($fn);
             $fn = str_replace('..', '', $fn);
             $fn = ltrim($fn, DS);
-            $fn = str_replace(DS.DS, DS, $fn);
             return $fn;
         }
 

--- a/import.php
+++ b/import.php
@@ -57,7 +57,9 @@
         }
 
         private static function sanitize($fn) {
-            $fn = str_replace('data:', 'user://data/', $fn);  // support legacy 'data:' paths
+            if (Utils::startswith($fn, 'data:')){
+                $fn = str_replace('data:', 'user://data/', $fn);  // support legacy 'data:' paths
+            }
             $fn = trim($fn);
             $fn = str_replace('..', '', $fn);
             $fn = ltrim($fn, DS);

--- a/import.php
+++ b/import.php
@@ -57,6 +57,7 @@
         }
 
         private static function sanitize($fn) {
+            $fn = str_replace('data:', 'user://data/', $fn);  // support legacy 'data:' paths
             $fn = trim($fn);
             $fn = str_replace('..', '', $fn);
             $fn = ltrim($fn, DS);

--- a/import.php
+++ b/import.php
@@ -48,7 +48,7 @@
         private function getContents($fn) {
             if (Utils::startswith($fn, 'data:')) {
                 $path = $this->grav['locator']->findResource('user://data', true);
-                $fn = ltrim(substr($fn, 5));
+                $fn = ltrim($fn, 'data:');
             } else {
                 $path = $this->grav['page']->path();
             }


### PR DESCRIPTION
If a path in `imports` contains `://`, then resolve it using the system locator `findResource()`; otherwise, resolve it as relative to the current page's path.

Summary of proposed changes:

* Use `basename()` to derive the key and strip the JSON/YAML extension for multiple imports
* If path contains `://` let `findResource()` resolve the entire path
* The `sanitize()` method was modified to prevent replacement of `//`. I'm actually not sure if any of the other lines in the method are needed.
* Added conversion of `data:` magic path to `user://data/` to support the legacy syntax